### PR TITLE
Fix 'preloading' of images

### DIFF
--- a/index.html
+++ b/index.html
@@ -240,15 +240,19 @@ ss.onclick = function() {
   }
 };
 
-// Pre-load an image for each URL, then start pinging with results recorded.
-// This speeds up subsequent requests. Otherwise, the first request to each IP
-// takes ~50-100ms longer, which is mysterious, because there isn't even a DNS
-// request. Oh well.
-let img = document.getElementById('pingimg');
-for (var key in _URLS) {
-  img.src = _URLS[key];
+let images = Object.values(_URLS);
+let image;
+let remaining = images.length;
+for (let i = 0; i < images.length; i++) {
+    image = new Image();
+    image.onerror = function () {
+        --remaining;
+        if (remaining <= 0) {
+            ss.onclick();
+        }
+    };
+    image.src = images[i];
 }
-ss.onclick();
 </script>
 
 <script>

--- a/index.html
+++ b/index.html
@@ -240,6 +240,10 @@ ss.onclick = function() {
   }
 };
 
+// Pre-load an image for each URL, then start pinging with results recorded.
+// This speeds up subsequent requests. Otherwise, the first request to each IP
+// takes double the RTT because it needs to establish a connection
+  
 let images = Object.values(_URLS);
 let image;
 let remaining = images.length;


### PR DESCRIPTION
The original version tried to establish a connection, but the code didn't actually work because the change to the src wasn't evaluated until the JS finished, and by that time it was too late. This delays starting the pings until all servers responded. It's onerror because the images aren't images.