### PR TITLE
Fix stop timeout

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,16 +283,18 @@ function updateTable() {
 
 let stopped = true;
 let ss = document.getElementById('stopstart');
+let st;
 ss.onclick = function() {
   if (stopped) {
     console.log('starting');
     stopped = false;
     ss.children[0].innerText = 'stop';
     document.dispatchEvent(new Event('nextping'));
-    setTimeout(ss.onclick, 30000); // stop after 30s.
+    st = setTimeout(ss.onclick, 30000); // stop after 30s.
   } else {
     console.log('stopping');
     stopped = true;
+    clearTimeout(st); // cancel the stop timeout, as it is stopped.
     ss.children[0].innerText = 'play_arrow';
   }
 };


### PR DESCRIPTION
If the ping is manually stopped, it will be restarted after the 30s timeout is fired. This clears the timeout so it won't be fired until it is manually clicked again. It also keeps only one timeout active at any given time, so that you won't have waves of start/stop happening every 30 seconds if you click a bunch of times.