### PR TITLE
Insert a space between the latency and "ms"

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,10 +271,10 @@ function updateTable() {
     var cls = (i == top) ? 'top' : '';
     var desc = _DESCS[region] || '';
     html += '<tr class="'+cls+'"><td class="regiondesc">'+desc+'<div class="region">'+region+'</div></td>' +
-      '<td class="result" id="'+region+'"><div>'+latency+'ms</div></td></tr>';
+      '<td class="result" id="'+region+'"><div>'+latency+' ms</div></td></tr>';
 
     if (place <= 3 && region != 'global') {
-      tweet += '\n'+region+' ('+latency+'ms)';
+      tweet += '\n'+region+' ('+latency+' ms)';
     }
   }
   document.getElementsByTagName('tbody')[0].innerHTML = html;


### PR DESCRIPTION
## What

This PR inserts a space between the latency number and "ms" of the result of measuring.

For example, the latency result will be `100ms` → `100 ms`.

## Why

- It's a formal notation of the number with unit
- This can improve the readability of the number